### PR TITLE
[FEAT] 퀴즈 목록 및 상세 화면 구현

### DIFF
--- a/EgenBoys/EgenBoys/Source/Feature/MainTabView.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/MainTabView.swift
@@ -34,7 +34,9 @@ enum TabItem: String, CaseIterable {
     var view: some View {
         switch self {
         case .quizList:
-            QuizListView()
+            NavigationView {
+                QuizListView()
+            }
         case .quizPlay:
             QuizPlayView()
         case .quizEditor:

--- a/EgenBoys/EgenBoys/Source/Feature/QuizList/CustomView/QuizItemView.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizList/CustomView/QuizItemView.swift
@@ -13,10 +13,11 @@ struct QuizItem: Identifiable {
     let description: String
     let imageURL: URL?
     let videoURL: URL?
+    var category: QuizCategory
 }
 
 struct QuizItemView: View {
-    @Binding var item: QuizItem
+    let item: QuizItem
     
     var body: some View {
         HStack {

--- a/EgenBoys/EgenBoys/Source/Feature/QuizList/CustomView/QuizItemView.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizList/CustomView/QuizItemView.swift
@@ -1,0 +1,51 @@
+//
+//  QuizItemView.swift
+//  EgenBoys
+//
+//  Created by 이건준 on 8/11/25.
+//
+
+import SwiftUI
+
+struct QuizItem: Identifiable {
+    let id = UUID()
+    let title: String
+    let description: String
+    let imageURL: URL?
+    let videoURL: URL?
+}
+
+struct QuizItemView: View {
+    @Binding var item: QuizItem
+    
+    var body: some View {
+        HStack {
+            if let imageURL = item.imageURL {
+                AsyncImage(url: imageURL) { image in
+                    image.resizable()
+                        .scaledToFill()
+                        .frame(width: 80, height: 80)
+                        .clipShape(RoundedRectangle(cornerRadius: 15))
+                        .shadow(radius: 5)
+                } placeholder: {
+                    ProgressView()
+                        .progressViewStyle(CircularProgressViewStyle(tint: .blue))
+                        .scaleEffect(1.5)
+                }
+                .frame(width: 80, height: 80)
+            }
+            
+            VStack(alignment: .leading, spacing: 8) {
+                Text(item.title)
+                    .font(.headline)
+                    .foregroundColor(.primary)
+                
+                Text(item.description)
+                    .font(.subheadline)
+                    .foregroundColor(.gray)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding()
+    }
+}

--- a/EgenBoys/EgenBoys/Source/Feature/QuizList/QuizDetailView.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizList/QuizDetailView.swift
@@ -1,0 +1,73 @@
+//
+//  QuizDetailView.swift
+//  EgenBoys
+//
+//  Created by 이건준 on 8/11/25.
+//
+
+import SwiftUI
+
+struct QuizDetailView: View {
+    @Binding var item: QuizItem
+    
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                if let imageURL = item.imageURL {
+                    AsyncImage(url: imageURL) { image in
+                        image.resizable()
+                            .scaledToFill()
+                            .frame(width: UIScreen.main.bounds.width - 40, height: 200)
+                            .clipShape(RoundedRectangle(cornerRadius: 15))
+                            .shadow(radius: 10)
+                    } placeholder: {
+                        ProgressView()
+                            .progressViewStyle(CircularProgressViewStyle(tint: .blue))
+                            .scaleEffect(1.5)
+                    }
+                    .padding(.horizontal)
+                }
+                
+                Text(item.title)
+                    .font(.title)
+                    .fontWeight(.bold)
+                    .foregroundColor(.primary)
+                    .padding(.horizontal)
+                    .lineLimit(.max)
+                    .multilineTextAlignment(.center)
+                
+                Text(item.description)
+                    .font(.body)
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal)
+                    .lineLimit(.max)
+                
+                Text(item.category.rawValue)
+                    .font(.caption)
+                    .fontWeight(.bold)
+                    .foregroundColor(.white)
+                    .padding(10)
+                    .background(
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(item.category == .all ? Color.blue : Color.green)
+                    )
+                    .shadow(color: .black.opacity(0.1), radius: 5, x: 0, y: 2)
+                    .padding(.top, 10)
+                
+                if let videoURL = item.videoURL {
+                    Link("Watch Video", destination: videoURL)
+                        .font(.headline)
+                        .foregroundColor(.blue)
+                        .padding()
+                        .frame(maxWidth: .infinity)
+                        .background(RoundedRectangle(cornerRadius: 10).stroke(Color.blue, lineWidth: 1))
+                        .padding(.top, 10)
+                }
+            }
+            .padding(.top, 20)
+            .padding(.bottom, 40)
+        }
+        .navigationBarTitle("퀴즈 상세", displayMode: .inline)
+    }
+}
+

--- a/EgenBoys/EgenBoys/Source/Feature/QuizList/QuizDetailView.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizList/QuizDetailView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct QuizDetailView: View {
-    @Binding var item: QuizItem
+    let item: QuizItem
     
     var body: some View {
         ScrollView {

--- a/EgenBoys/EgenBoys/Source/Feature/QuizList/QuizListVIew.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizList/QuizListVIew.swift
@@ -7,33 +7,60 @@
 
 import SwiftUI
 
+enum QuizCategory: String, CaseIterable {
+    case all = "모든 퀴즈"
+    case ios = "iOS"
+    case design = "Design"
+    case cs = "CS"
+}
+
 struct QuizListView: View {
+    @State private var selectedCategory: QuizCategory = .all
     @State private var quizList: [QuizItem] = [
         QuizItem(
             title: "첫번째 퀴즈",
             description: "이 퀴즈는 SwiftUI에 대한 기본적인 이해를 테스트합니다.",
             imageURL: URL(string: "https://plus.unsplash.com/premium_photo-1668736594225-55e292fdd95e?w=700&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8JUVEJTgwJUI0JUVDJUE2JTg4fGVufDB8fDB8fHww"),
-            videoURL: URL(string: "https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+            videoURL: URL(string: "https://www.youtube.com/watch?v=dQw4w9WgXcQ"),
+            category: .cs
         ),
         QuizItem(
             title: "두번째 퀴즈",
             description: "이 퀴즈는 Swift 언어에 대한 질문입니다.",
             imageURL: URL(string: "https://plus.unsplash.com/premium_photo-1678216286021-e81f66761751?w=700&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8OXx8JUVEJTgwJUI0JUVDJUE2JTg4fGVufDB8fDB8fHww"),
-            videoURL: URL(string: "https://www.youtube.com/watch?v=J---aiyznGQ")
+            videoURL: URL(string: "https://www.youtube.com/watch?v=J---aiyznGQ"),
+            category: .design
         ),
         QuizItem(
             title: "세번째 퀴즈",
             description: "iOS 개발에 관련된 다양한 기술적 질문을 다룹니다.",
             imageURL: URL(string: "https://images.unsplash.com/photo-1516321497487-e288fb19713f?w=700&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MTB8fCVFRCU4MCVCNCVFQyVBNiU4OHxlbnwwfHwwfHx8MA%3D%3D"),
-            videoURL: URL(string: "https://www.youtube.com/watch?v=QH2-TGUlwu4")
+            videoURL: URL(string: "https://www.youtube.com/watch?v=QH2-TGUlwu4"),
+            category: .ios
         )
     ]
+    private var filteredQuizList: [QuizItem] {
+        if selectedCategory == .all {
+            return quizList
+        } else {
+            return quizList.filter { $0.category == selectedCategory }
+        }
+    }
     
     var body: some View {
-        List {
-            ForEach($quizList) { item in
-                NavigationLink(destination: QuizDetailView(item: item)) {
-                    QuizItemView(item: item)
+        VStack {
+            Picker("카테고리 선택", selection: $selectedCategory) {
+                ForEach(QuizCategory.allCases, id: \.self) { category in
+                    Text(category.rawValue).tag(category)
+                }
+            }
+            .pickerStyle(SegmentedPickerStyle())
+            .padding()
+            List {
+                ForEach(filteredQuizList) { item in
+                    NavigationLink(destination: QuizDetailView(item: item)) {
+                        QuizItemView(item: item)
+                    }
                 }
                 .listRowInsets(EdgeInsets(top: .zero, leading: .zero, bottom: .zero, trailing: 15))
             }

--- a/EgenBoys/EgenBoys/Source/Feature/QuizList/QuizListVIew.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizList/QuizListVIew.swift
@@ -8,8 +8,37 @@
 import SwiftUI
 
 struct QuizListView: View {
+    @State private var quizList: [QuizItem] = [
+        QuizItem(
+            title: "첫번째 퀴즈",
+            description: "이 퀴즈는 SwiftUI에 대한 기본적인 이해를 테스트합니다.",
+            imageURL: URL(string: "https://plus.unsplash.com/premium_photo-1668736594225-55e292fdd95e?w=700&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8JUVEJTgwJUI0JUVDJUE2JTg4fGVufDB8fDB8fHww"),
+            videoURL: URL(string: "https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+        ),
+        QuizItem(
+            title: "두번째 퀴즈",
+            description: "이 퀴즈는 Swift 언어에 대한 질문입니다.",
+            imageURL: URL(string: "https://plus.unsplash.com/premium_photo-1678216286021-e81f66761751?w=700&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8OXx8JUVEJTgwJUI0JUVDJUE2JTg4fGVufDB8fDB8fHww"),
+            videoURL: URL(string: "https://www.youtube.com/watch?v=J---aiyznGQ")
+        ),
+        QuizItem(
+            title: "세번째 퀴즈",
+            description: "iOS 개발에 관련된 다양한 기술적 질문을 다룹니다.",
+            imageURL: URL(string: "https://images.unsplash.com/photo-1516321497487-e288fb19713f?w=700&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MTB8fCVFRCU4MCVCNCVFQyVBNiU4OHxlbnwwfHwwfHx8MA%3D%3D"),
+            videoURL: URL(string: "https://www.youtube.com/watch?v=QH2-TGUlwu4")
+        )
+    ]
+    
     var body: some View {
-        Text("퀴즈 목록 화면")
+        List {
+            ForEach($quizList) { item in
+                NavigationLink(destination: QuizDetailView(item: item)) {
+                    QuizItemView(item: item)
+                }
+                .listRowInsets(EdgeInsets(top: .zero, leading: .zero, bottom: .zero, trailing: 15))
+            }
+            .animation(.easeInOut, value: selectedCategory)
+        }
     }
 }
 


### PR DESCRIPTION
## 작업 내용

- [ ] QuizItemView, QuizDetailView, QuizListView 화면 구현
- [ ] QuizCategory에 따른 필터링 로직 추가 및 애니메이션 추가

## 화면 (Optional)
|퀴즈 목록|퀴즈 상세|
|:-:|:-:|
|<img width="200" height="400" alt="simulator_screenshot_46C08A3D-F86A-49DA-AE3E-37F4F2C58183" src="https://github.com/user-attachments/assets/2a00a1b0-75dd-4142-94d9-cdda907a5ac9" />|<img width="200" height="400" alt="simulator_screenshot_A80C9392-2F3A-43AF-B00A-4D0430525455" src="https://github.com/user-attachments/assets/75a2f03e-aba3-41de-b57e-0fad82414b96" />|

### 퀴즈 목록 필터 선택
[화면 녹화 링크](https://github.com/user-attachments/assets/fb297cc4-48b9-4c12-b5eb-71964e069e8d)

### 퀴즈 목록 -> 퀴즈 상세 
[화면 녹화 링크](https://github.com/user-attachments/assets/cfc11ecf-eb0b-4dd7-9f29-2c85d2639965)

<br/><br/><br/>
## 논의 해봤으면 좋으점 (Optional)
- @funrace2 현모님이 구현해주시는 퀴즈생성화면에서 제가 구현한 'QuizCategory', 'QuizItem'이 동일해서 같은 모델로 수정해주시면 좋을꺼같습니다.
- 아직 퀴즈 상세화면에서 선택할 수 있는 질문리스트에 관련된 UI가 없는데 현모님 코드 병합 이후 수정해놓도록 하겠습니다.
