### PR TITLE
[FEAT] 퀴즈 등록 화면 구현 및 미디어 추가 기능 추가

### DIFF
--- a/EgenBoys/EgenBoys/Source/Feature/QuizEditor/QuizEditorView.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizEditor/QuizEditorView.swift
@@ -24,7 +24,7 @@ struct QuizEditorView: View {
     @State private var difficulty: [String] = ["쉬움", "보통", "어려움"]
     @State private var selectedDifficulty: String = "보통"
     
-    @State private var categories: [String] = ["iOS", "Design", "CS", "직접 추가하기..."]
+    @State private var categories: [String] = QuizCategory.allCases.filter { $0 != .all}.map { $0.rawValue } + ["직접 추가하기..."]
     @State private var selectedCategory: String = "iOS"
     @State private var newCategoryName: String = ""
     @State private var isShowingAlert: Bool = false

--- a/EgenBoys/EgenBoys/Source/Feature/QuizEditor/QuizEditorView.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizEditor/QuizEditorView.swift
@@ -2,7 +2,7 @@
 //  QuizEditorView.swift
 //  EgenBoys
 //
-//  Created by 이건준 on 8/11/25.
+//  Created by 구현모 on 8/11/25.
 //
 
 import SwiftUI
@@ -24,7 +24,7 @@ struct QuizEditorView: View {
     @State private var selectedDifficulty: String = "보통"
     
     @State private var categories: [String] = ["iOS", "Design", "CS", "직접 추가하기..."]
-    @State private var selectedCategory: String = "iOS"
+    @State private var selectedCategories: Set<String> = []
     @State private var newCategoryName: String = ""
     @State private var isShowingAlert: Bool = false
     
@@ -89,15 +89,32 @@ struct QuizEditorView: View {
                     }
                     .pickerStyle(.menu)
                     
-                    Picker("카테고리", selection: $selectedCategory) {
-                        ForEach(categories, id: \.self) { category in
-                            Text(category)
-                        }
-                    }
-                    .pickerStyle(.menu)
-                    .onChange(of: selectedCategory) { newValue in
-                        if newValue == "직접 추가하기..." {
-                            self.isShowingAlert = true
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("카테고리")
+                        LazyVGrid(columns: [GridItem(.adaptive(minimum: 80))], spacing: 10) {
+                            ForEach(categories, id: \.self) { category in
+                                if category == "직접 추가하기..." {
+                                    Button(action: {
+                                        isShowingAlert = true
+                                    }) {
+                                        Image(systemName: "plus")
+                                            .frame(maxWidth: .infinity, minHeight: 20)
+                                    }
+                                    .buttonStyle(.bordered)
+                                } else {
+                                    Button(action: {
+                                        toggleCategorySelection(category)
+                                    }) {
+                                        Text(category)
+                                            .font(.system(size: 14))
+                                            .frame(maxWidth: .infinity, minHeight: 25)
+                                    }
+                                    .background(selectedCategories.contains(category) ? Color.accentColor : Color.secondary.opacity(0.2))
+                                    .foregroundColor(selectedCategories.contains(category) ? .white : .primary)
+                                    .cornerRadius(8)
+                                    .buttonStyle(.plain)
+                                }
+                            }
                         }
                     }
                 }
@@ -142,14 +159,12 @@ struct QuizEditorView: View {
                 }
                 .listRowInsets(EdgeInsets()) // 버튼 바깥 여백 제거
             }
-            .navigationTitle("퀴즈 등록")
+            .navigationTitle("퀴즈 등록 / 편집")
             .navigationBarTitleDisplayMode(.inline)
             .alert("새 카테고리 추가", isPresented: $isShowingAlert) {
                 TextField("카테고리 이름", text: $newCategoryName)
-                Button("추가", action: addNewCategory)
-                Button("취소", role: .cancel) {
-                    selectedCategory = categories.first ?? "iOS"
-                }
+                Button("추가", action: addNewCategories)
+                Button("취소", role: .cancel) { }
             } message: {
                 Text("추가할 카테고리의 이름을 입력해주세요.")
             }
@@ -179,6 +194,7 @@ struct QuizEditorView: View {
                     }
                 }
             }
+            .ignoresSafeArea(.keyboard, edges: .bottom)
         }
     }
     
@@ -198,15 +214,21 @@ struct QuizEditorView: View {
         correctAnswerIndex.removeAll()
     }
     
-    func addNewCategory() {
-        let trimmedName = newCategoryName.trimmingCharacters(in: .whitespaces)
-        guard !trimmedName.isEmpty else {
-            return
+    func toggleCategorySelection(_ category: String) {
+        if selectedCategories.contains(category) {
+            selectedCategories.remove(category)
+        } else {
+            selectedCategories.insert(category)
         }
-        
-        categories.insert(trimmedName, at: categories.count - 1)
-        selectedCategory = trimmedName
-        newCategoryName = ""
+    }
+    func addNewCategories() {
+        let trimmedName = newCategoryName.trimmingCharacters(in: .whitespaces)
+            guard !trimmedName.isEmpty else {
+                return
+            }
+            categories.insert(trimmedName, at: categories.count - 1)
+            selectedCategories.insert(trimmedName)
+            newCategoryName = ""
     }
     
     @ViewBuilder

--- a/EgenBoys/EgenBoys/Source/Feature/QuizEditor/QuizEditorView.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizEditor/QuizEditorView.swift
@@ -2,7 +2,7 @@
 //  QuizEditorView.swift
 //  EgenBoys
 //
-//  Created by 구현모 on 8/11/25.
+//  Created by 구현모 on 8/12/25.
 //
 
 import SwiftUI
@@ -149,7 +149,22 @@ struct QuizEditorView: View {
                 
                 Section {
                     Button("저장하기") {
-                        
+                        print("--------------- 퀴즈 저장 정보 ---------------")
+                        print("질문: \(question)")
+                        print("보기 목록: \(answer)")
+                        print("정답 인덱스: \(correctAnswerIndex)")
+                        print("난이도: \(selectedDifficulty)")
+                        print("선택된 카테고리: \(selectedCategories)")
+                                
+                        if selectedMediaItems.isEmpty {
+                            print("첨부된 미디어: 없음")
+                        } else {
+                            print("첨부된 미디어: \(selectedMediaItems.count)개")
+                            for (index, media) in selectedMediaItems.enumerated() {
+                                print("  - 미디어 \(index + 1): 타입 \(media.type), 데이터 \(media.data.count) 바이트")
+                            }
+                        }
+                        print("-------------------------------------------")
                     }
                     .frame(minWidth: 0, maxWidth: .infinity)
                     .padding()
@@ -163,6 +178,7 @@ struct QuizEditorView: View {
             .navigationBarTitleDisplayMode(.inline)
             .alert("새 카테고리 추가", isPresented: $isShowingAlert) {
                 TextField("카테고리 이름", text: $newCategoryName)
+                    .autocorrectionDisabled()
                 Button("추가", action: addNewCategories)
                 Button("취소", role: .cancel) { }
             } message: {

--- a/EgenBoys/EgenBoys/Source/Feature/QuizEditor/QuizEditorView.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizEditor/QuizEditorView.swift
@@ -37,11 +37,6 @@ struct QuizEditorView: View {
         let data: Data
         var previewURL: URL?
     }
-
-//    @State private var selectedPhotoItem: PhotosPickerItem?
-//    @State private var selectedMediaData: Data?
-//    @State private var selectedMediaType: MediaType?
-//    @State private var videoPreviewURL: URL?
     
     var body: some View {
         NavigationStack {
@@ -51,20 +46,38 @@ struct QuizEditorView: View {
                         .autocorrectionDisabled()
                 }
                 
-                Section("보기 및 정답") {
-                    ForEach(0..<answer.count, id: \.self) { index in
-                        HStack {
-                            TextField("\(index + 1). 선택지를 입력하세요.", text: $answer[index])
-                                .autocorrectionDisabled()
-                                .padding(.vertical, 8)
-                            Button(action: {
-                                toggleAnswerSelection(at: index)
-                            }) {
-                                Image(systemName: correctAnswerIndex.contains(index) ? "checkmark.square.fill" : "square")
+                Section("보기 및 정답 체크") {
+                    VStack {
+                        ForEach(0..<answer.count, id: \.self) { index in
+                            HStack {
+                                TextField("\(index + 1). 선택지를 입력하세요.", text: $answer[index])
+                                    .autocorrectionDisabled()
+                                    .padding(.vertical, 8)
+                                Button(action: {
+                                    toggleAnswerSelection(at: index)
+                                }) {
+                                    Image(systemName: correctAnswerIndex.contains(index) ? "checkmark.square.fill" : "square")
+                                }
+                                .buttonStyle(.plain)
+                                
+                                if answer.count > 2 {
+                                    Button(action: {
+                                        removeAnswer(at: index)
+                                    }) {
+                                        Image(systemName: "trash")
+                                            .foregroundColor(.red)
+                                    }
+                                    .buttonStyle(.plain)
+                                }
                             }
-                            .buttonStyle(.plain)
+                            .padding()
                         }
-                        .padding()
+                        Button(action: addAnswer) {
+                            HStack {
+                                Image(systemName: "plus.circle.fill")
+                                Text("보기 추가")
+                            }
+                        }
                     }
                 }
                 
@@ -175,6 +188,14 @@ struct QuizEditorView: View {
         } else {
             correctAnswerIndex.insert(index)
         }
+    }
+    
+    func addAnswer() {
+        answer.append("")
+    }
+    func removeAnswer(at index: Int) {
+        answer.remove(at: index)
+        correctAnswerIndex.removeAll()
     }
     
     func addNewCategory() {

--- a/EgenBoys/EgenBoys/Source/Feature/QuizEditor/QuizEditorView.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizEditor/QuizEditorView.swift
@@ -87,6 +87,8 @@ struct QuizEditorView: View {
                                 Text("보기 추가")
                             }
                         }
+                        .buttonStyle(.plain)
+                        .foregroundColor(.blue)
                     }
                 }
                 

--- a/EgenBoys/EgenBoys/Source/Feature/QuizEditor/QuizEditorView.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizEditor/QuizEditorView.swift
@@ -230,6 +230,7 @@ struct QuizEditorView: View {
     func addNewCategory() {
         let trimmedName = newCategoryName.trimmingCharacters(in: .whitespaces)
         guard !trimmedName.isEmpty else {
+            selectedCategory = categories.first ?? "iOS"
             return
         }
         


### PR DESCRIPTION
# **작업 내용**
- QuizEditorView 화면 구현
- 미디어 다중 선택 기능, 미리보기 기능 구현
- 문제 설명 탭 추가
- 보기 추가 기능, 복수정답 체크 기능, 난이도 선택 기능 추가
- QuizCategory 열거형을 사용해 동적으로 카테고리 생성 가능하도록 수정
- 저장 시 print문으로 로그 확인 가능

# **화면**
| 퀴즈 등록 화면 1 | 퀴즈 등록 화면 2 |
| :-: | :-: |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-12 at 13 23 29" src="https://github.com/user-attachments/assets/5f75cdac-5f90-479a-a4c4-f54f2f5af0ca" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-12 at 13 23 32" src="https://github.com/user-attachments/assets/85c1ce50-741b-41f0-af61-c3874489f947" /> |

| 사진 / 영상 첨부 화면 | 사진 / 영상 미리 보기 기능 |
| :-: | :-: |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-12 at 13 23 56" src="https://github.com/user-attachments/assets/cdc5cd2c-ebf8-4afd-988f-6ef184086bc6" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-12 at 13 24 05" src="https://github.com/user-attachments/assets/012fcc04-9cc0-47ec-8525-9655b8fdb126" /> |

### 카테고리 생성

https://github.com/user-attachments/assets/1bcc6323-4ec1-4685-a2f7-4d5cca8ff9d9

## 로그 출력
| | |
| :-: | :-: |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-12 at 13 47 46" src="https://github.com/user-attachments/assets/69226899-8266-4ebf-8973-fc6fc9a1adc0" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-12 at 13 47 52" src="https://github.com/user-attachments/assets/decd0595-ba5c-49d0-8761-a7e5d8714850" /> |


``` zsh
--------------- 퀴즈 저장 정보 ---------------
질문: 테스트용 문제
설명: 테스트용 설명
보기 목록: ["테스트 선택지 1", "테스트 선택지 2", "테스트 선택지 3", "테스트 선택지 4", "테스트 선택지 5"]
정답 인덱스: [2, 3]
난이도: 보통
선택된 카테고리: 테스트 카테고리
첨부된 미디어: 2개
  - 미디어 1: 타입 video, 데이터 16371927 바이트
  - 미디어 2: 타입 image, 데이터 1484294 바이트
-------------------------------------------
```
