### PR TITLE
[FEAT] 중복 체크 기능 추가 및 제출화면 중복 체크의 경우 퍼센트로 나타내는 기능 추가

### DIFF
--- a/EgenBoys/EgenBoys/Source/Feature/QuizPlay/QuizPlayModels.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizPlay/QuizPlayModels.swift
@@ -1,0 +1,80 @@
+//
+//  QuizPlayModels.swift
+//  EgenBoys
+//
+//  Created by 정수안 on 8/12/25.
+//
+// QuizPlayModels.swift
+import Foundation
+
+/// 세션(풀이) 화면에서 쓰는 가벼운 모델
+/// - answerIndices: 0-based 인덱스 (복수 정답 가능)
+struct QuizQuestion: Identifiable, Hashable {
+    let id = UUID()
+    let text: String
+    let options: [String]
+    let answerIndices: Set<Int>
+
+    init(text: String, options: [String], answerIndices: Set<Int>) {
+        self.text = text
+        self.options = options
+        self.answerIndices = answerIndices
+    }
+}
+
+// 미리보기/개발용 샘플
+extension QuizQuestion {
+    static let sample: [QuizQuestion] = [
+        .init(text: "샘플1", options: ["1","2","3","4"], answerIndices: [1,3]),
+        .init(text: "샘플2", options: ["A","B","C","D"], answerIndices: [0]),
+        .init(text: "샘플3", options: ["가","나","다","라"], answerIndices: [2]),
+        .init(text: "샘플4", options: ["봄","여름","가을","겨울"], answerIndices: [1,2]),
+        .init(text: "샘플5", options: ["x","y","z","w"], answerIndices: [3]),
+    ]
+}
+
+// -------- 어댑터(팀 데이터 → 세션 모델) --------
+// 팀 모델 구조에 맞게 아래 두 개 중 하나(또는 둘 다)만 남겨 쓰세요.
+
+// 1) 팀이 정답을 "인덱스 배열"로 줄 때
+struct TeamQuestionIndex {
+    let title: String
+    let choices: [String]
+    let correctIndexes: [Int]   // 0-based
+}
+
+extension Array where Element == TeamQuestionIndex {
+    func toSessionQuestions() -> [QuizQuestion] {
+        map { tq in
+            QuizQuestion(
+                text: tq.title,
+                options: tq.choices,
+                answerIndices: Set(tq.correctIndexes)
+            )
+        }
+    }
+}
+
+// 2) 팀이 정답을 "텍스트 배열"로 줄 때
+struct TeamQuestionText {
+    let title: String
+    let choices: [String]
+    let correctTexts: [String]
+}
+
+extension Array where Element == TeamQuestionText {
+    func toSessionQuestions() -> [QuizQuestion] {
+        map { tq in
+            let idxSet = Set(
+                tq.choices.enumerated()
+                    .compactMap { tq.correctTexts.contains($0.element) ? $0.offset : nil }
+            )
+            return QuizQuestion(
+                text: tq.title,
+                options: tq.choices,
+                answerIndices: idxSet
+            )
+        }
+    }
+}
+

--- a/EgenBoys/EgenBoys/Source/Feature/QuizPlay/QuizPlayView.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizPlay/QuizPlayView.swift
@@ -2,14 +2,16 @@
 //  QuizPlayView.swift
 //  EgenBoys
 //
-//  Created by 이건준 on 8/11/25.
+//  Created by 정수안 on 8/11/25.
 //
 
 import SwiftUI
 
 struct QuizPlayView: View {
     var body: some View {
-        Text("퀴즈 풀기 화면")
+        NavigationStack {
+            StartQuizView()
+        }
     }
 }
 

--- a/EgenBoys/EgenBoys/Source/Feature/QuizPlay/QuizSessionView.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizPlay/QuizSessionView.swift
@@ -1,0 +1,99 @@
+//
+//  QuizSessionView.swift
+//  EgenBoys
+//
+//  Created by 정수안 on 8/11/25.
+//
+
+import SwiftUI
+
+struct QuizSessionView: View {
+    // 한 문제만 UI 테스트
+    @State private var currentIndex: Int = 0
+    private let totalCount: Int = 1
+
+    @State private var questionText: String =
+        "질문"
+    @State private var options: [String] = [
+        "@1", "@2", "@3", "@4"
+    ]
+    
+    private let answerIndex: Int = 1
+
+    @State private var selectedID: Int? = nil
+
+    @State private var showSummary = false
+    @State private var dummyCorrect = 0  // 제출 시 계산해서 채움
+
+    var body: some View {
+        VStack(spacing: 16) {
+            // 상단 진행도
+            VStack(spacing: 6) {
+                ProgressView(value: Double(currentIndex+1), total: Double(totalCount))
+                    .tint(.blue)
+                    .padding(.horizontal)
+                Text("\(currentIndex+1) / \(totalCount)")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.top, 6)
+
+            ScrollView {
+                VStack(spacing: 16) {
+                    SectionCard("문제") {
+                        Text(questionText)
+                            .font(.title3.bold())
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+
+                    SectionCard("보기") {
+                        VStack(spacing: 10) {
+                            ForEach(options.indices, id: \.self) { i in
+                                CheckboxRow(index: i+1,
+                                            text: options[i],
+                                            isSelected: selectedID == i)
+                                .onTapGesture { selectedID = i }
+                            }
+                        }
+                    }
+                }
+                .padding(.horizontal, 16)
+                .padding(.bottom, 10)
+            }
+
+            // 하단 버튼
+            Button {
+                // ✅ 제출 시 정답 체크
+                dummyCorrect = (selectedID == answerIndex) ? 1 : 0
+                showSummary = true
+            } label: {
+                Text("제출하기")
+                    .fontWeight(.semibold)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background((selectedID == nil) ? Color.gray.opacity(0.3) : Color.blue)
+                    .foregroundColor((selectedID == nil) ? .gray : .white)
+                    .clipShape(RoundedRectangle(cornerRadius: 14))
+            }
+            .disabled(selectedID == nil)
+            .padding(.horizontal, 16)
+            .padding(.bottom, 12)
+        }
+        .navigationTitle("문제 풀이")
+        .navigationBarTitleDisplayMode(.inline)
+        .sheet(isPresented: $showSummary) {
+            QuizSummaryView(total: totalCount, correct: dummyCorrect) {
+                // 닫기 후 리셋
+                currentIndex = 0
+                selectedID = nil
+                showSummary = false
+                dummyCorrect = 0
+            }
+            .presentationDetents([.fraction(0.85)])
+        }
+    }
+}
+
+#Preview {
+    NavigationStack { QuizSessionView() }
+}

--- a/EgenBoys/EgenBoys/Source/Feature/QuizPlay/QuizSessionView.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizPlay/QuizSessionView.swift
@@ -7,31 +7,34 @@
 
 import SwiftUI
 
+// 세션에서 쓰는 질문 모델은 QuizPlayModels.swift에 있음:
+// struct QuizQuestion { let text: String; let options: [String]; let answerIndices: Set<Int> }
+
 struct QuizSessionView: View {
-    // 한 문제만 UI 테스트
-    @State private var currentIndex: Int = 0
-    private let totalCount: Int = 1
-
-    @State private var questionText: String = "질문"
-    @State private var options: [String] = ["@1", "@2", "@3", "@4"]
-
-    // ✅ 정답(복수 가능) 내가 정하는것
-    private let answerIndices: Set<Int> = [1, 3]
-
-    // ✅ 복수선택 상태
-    @State private var selectedIDs: Set<Int> = []
-
+    // ✅ N문제 받아서 풀이 (없으면 샘플로 대체)
+    let questions: [QuizQuestion]
+    @State private var index: Int = 0
+    @State private var selections: [Int: Set<Int>] = [:]   // 문항별 선택 저장
     @State private var showSummary = false
-    @State private var scorePercent = 0  // 제출 시 계산해서 채움 (0~100)
+    @State private var finalPercent = 0
+
+    // ✅ 디폴트 init: 인자로 안 주면 샘플 사용
+    init(questions: [QuizQuestion]? = nil) {
+        self.questions = questions ?? QuizQuestion.sample
+    }
 
     var body: some View {
+        let total = max(questions.count, 1)
+        let q = questions[index]
+        let selected = selections[index] ?? []
+
         VStack(spacing: 16) {
-            // 상단 진행도
+            // 진행도
             VStack(spacing: 6) {
-                ProgressView(value: Double(currentIndex+1), total: Double(totalCount))
+                ProgressView(value: Double(index + 1), total: Double(total))
                     .tint(.blue)
                     .padding(.horizontal)
-                Text("\(currentIndex+1) / \(totalCount)")
+                Text("\(index + 1) / \(total)")
                     .font(.footnote)
                     .foregroundStyle(.secondary)
             }
@@ -40,25 +43,23 @@ struct QuizSessionView: View {
             ScrollView {
                 VStack(spacing: 16) {
                     SectionCard("문제") {
-                        Text(questionText)
+                        Text(q.text)
                             .font(.title3.bold())
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
 
                     SectionCard("보기") {
                         VStack(spacing: 10) {
-                            ForEach(options.indices, id: \.self) { i in
+                            ForEach(q.options.indices, id: \.self) { i in
                                 CheckboxRow(
-                                    index: i+1,
-                                    text: options[i],
-                                    isSelected: selectedIDs.contains(i)
+                                    index: i + 1,
+                                    text: q.options[i],
+                                    isSelected: selected.contains(i)
                                 )
                                 .onTapGesture {
-                                    if selectedIDs.contains(i) {
-                                        selectedIDs.remove(i)
-                                    } else {
-                                        selectedIDs.insert(i)
-                                    }
+                                    var s = selections[index] ?? []
+                                    if s.contains(i) { s.remove(i) } else { s.insert(i) }
+                                    selections[index] = s
                                 }
                             }
                         }
@@ -68,65 +69,67 @@ struct QuizSessionView: View {
                 .padding(.bottom, 10)
             }
 
-            // 하단 버튼
             Button {
-                // ✅ 부분 점수 계산 → 0~100 퍼센트
-                scorePercent = computeScorePercent(
-                    selected: selectedIDs,
-                    answers: answerIndices,
-                    optionCount: options.count
-                )
-                showSummary = true
+                if index < total - 1 {
+                    index += 1
+                } else {
+                    finalPercent = overallPercent()
+                    showSummary = true
+                }
             } label: {
-                Text("제출하기")
+                Text(index == total - 1 ? "제출하기" : "다음으로")
                     .fontWeight(.semibold)
                     .frame(maxWidth: .infinity)
                     .padding()
-                    .background(selectedIDs.isEmpty ? Color.gray.opacity(0.3) : Color.blue)
-                    .foregroundColor(selectedIDs.isEmpty ? .gray : .white)
+                    .background(selected.isEmpty ? Color.gray.opacity(0.3) : Color.blue)
+                    .foregroundColor(selected.isEmpty ? .gray : .white)
                     .clipShape(RoundedRectangle(cornerRadius: 14))
             }
-            .disabled(selectedIDs.isEmpty)
+            .disabled(selected.isEmpty)
             .padding(.horizontal, 16)
             .padding(.bottom, 12)
         }
         .navigationTitle("문제 풀이")
         .navigationBarTitleDisplayMode(.inline)
         .sheet(isPresented: $showSummary) {
-            // ✅ 퍼센트 기반 요약 뷰
-            QuizSummaryScoreView(percent: scorePercent) {
-                // 닫기 후 리셋
-                currentIndex = 0
-                selectedIDs.removeAll()
+            QuizSummaryScoreView(percent: finalPercent) {
+                index = 0
+                selections.removeAll()
                 showSummary = false
-                scorePercent = 0
+                finalPercent = 0
             }
             .presentationDetents([.fraction(0.85)])
         }
     }
+
+    // 각 문항 점수(%) 평균
+    private func overallPercent() -> Int {
+        guard !questions.isEmpty else { return 0 }
+        let percents = questions.enumerated().map { (idx, q) in
+            computeScorePercent(
+                selected: selections[idx] ?? [],
+                answers: q.answerIndices,
+                optionCount: q.options.count
+            )
+        }
+        let avg = Double(percents.reduce(0, +)) / Double(percents.count)
+        return Int(round(avg))
+    }
 }
 
-// ✅ 부분점수 계산 로직
-/// - hit: 맞게 고른 개수 / 정답 개수  → 기본 가산
-/// - wrong: 오답 선택 개수 / (전체 보기 - 정답 수)  → 패널티 0.5배
-/// - 최종: clamp( (hitRatio) - 0.5*(wrongRatio), 0...1 ) * 100
+// 그대로 사용
 private func computeScorePercent(selected: Set<Int>, answers: Set<Int>, optionCount: Int) -> Int {
     let hit = selected.intersection(answers).count
     let wrong = selected.subtracting(answers).count
-
     let answerCount = max(1, answers.count)
-    let nonAnswerCount = max(1, optionCount - answers.count) // 0 분모 방지
-
+    let nonAnswerCount = max(1, optionCount - answers.count)
     let hitRatio = Double(hit) / Double(answerCount)
     let wrongRatio = Double(wrong) / Double(nonAnswerCount)
-
-    // 패널티 가중치는 0.5 (원하면 0.3~1.0 사이로 조절)
     let raw = hitRatio - 0.5 * wrongRatio
-    let clamped = max(0, min(1, raw))
-
-    return Int(round(clamped * 100))
+    return Int(round(max(0, min(1, raw)) * 100))
 }
 
 #Preview {
+    // 샘플 주입 없이도 동작(디폴트 init)
     NavigationStack { QuizSessionView() }
 }

--- a/EgenBoys/EgenBoys/Source/Feature/QuizPlay/QuizSessionView.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizPlay/QuizSessionView.swift
@@ -7,18 +7,23 @@
 
 import SwiftUI
 
-// 세션에서 쓰는 질문 모델은 QuizPlayModels.swift에 있음:
-// struct QuizQuestion { let text: String; let options: [String]; let answerIndices: Set<Int> }
-
+// QuizQuestion / ChoiceFeedback / SectionCard / CheckboxRow 는
+// 각각 QuizPlayModels.swift / QuizUIComponents.swift 에 있다고 가정합니다.
 
 struct QuizSessionView: View {
+    
     let questions: [QuizQuestion]
     @State private var index: Int = 0
-    @State private var selections: [Int: Set<Int>] = [:]
-    @State private var revealed: Bool = false               // ✅ 정답 공개 여부
+    @State private var selections: [Int: Set<Int>] = [:]   // 문항별 선택 저장
+    @State private var revealed: Bool = false               // 정답 공개 여부
     @State private var showSummary = false
     @State private var finalPercent = 0
 
+    // 여기 수정함!! Start 로 돌아가기 위해 pop
+    @Environment(\.dismiss) private var dismiss
+    @State private var popAfterSummary = false              // 시트 닫힌 뒤 pop 플래그
+
+    
     init(questions: [QuizQuestion]? = nil) {
         self.questions = questions ?? QuizQuestion.sample
     }
@@ -29,7 +34,7 @@ struct QuizSessionView: View {
         let selected = selections[index] ?? []
 
         VStack(spacing: 16) {
-            // 진행도
+          
             VStack(spacing: 6) {
                 ProgressView(value: Double(index + 1), total: Double(total))
                     .tint(.blue)
@@ -58,7 +63,7 @@ struct QuizSessionView: View {
                                 )
                                 .contentShape(Rectangle())
                                 .onTapGesture {
-                                    guard !revealed else { return } // 공개 후에는 잠금
+                                    guard !revealed else { return } // 공개 후엔 잠금
                                     var s = selections[index] ?? []
                                     if s.contains(i) { s.remove(i) } else { s.insert(i) }
                                     selections[index] = s
@@ -97,35 +102,42 @@ struct QuizSessionView: View {
                     .foregroundColor((selected.isEmpty && !revealed) ? .gray : .white)
                     .clipShape(RoundedRectangle(cornerRadius: 14))
             }
-            .disabled(selected.isEmpty && !revealed)   // 선택 전에는 공개 버튼 비활성화
+            .disabled(selected.isEmpty && !revealed)   // 선택 전엔 공개 버튼 비활성화
             .padding(.horizontal, 16)
             .padding(.bottom, 12)
         }
         .navigationTitle("문제 풀이")
         .navigationBarTitleDisplayMode(.inline)
         .sheet(isPresented: $showSummary) {
+            // ⬇️ 퍼센트 요약 시트 (total/correct 버전 써도 onClose 동일)
             QuizSummaryScoreView(percent: finalPercent) {
+                // 시트 닫기 + 이후 pop하도록 표시
+                popAfterSummary = true
+                showSummary = false
+
+                // (선택) 다음 풀이 대비 초기화
                 index = 0
                 selections.removeAll()
                 revealed = false
-                showSummary = false
                 finalPercent = 0
             }
             .presentationDetents([.fraction(0.85)])
         }
+        // 시트가 실제로 닫힌 시점에 Start 화면으로 pop
+        .onChange(of: showSummary) { isPresented in
+            if !isPresented && popAfterSummary {
+                popAfterSummary = false
+                dismiss()   // ← NavigationStack에서 한 단계 뒤로
+            }
+        }
     }
 
-    // ✅ 각 옵션의 피드백 상태 계산
+    // 각 옵션의 피드백 상태 계산
     private func feedbackState(for i: Int, selected: Set<Int>, answers: Set<Int>) -> ChoiceFeedback? {
         guard revealed else { return nil } // 공개 전엔 색상 피드백 없음
-
-        if answers.contains(i) {                 // 정답은 초록(선택 여부 무관)
-            return .correct
-        } else if selected.contains(i) {         // 선택한 오답은 빨강
-            return .wrong
-        } else {                                 // 나머지는 흐리게
-            return .dimmed
-        }
+        if answers.contains(i) { return .correct }      // 정답 = 초록
+        if selected.contains(i) { return .wrong }       // 선택한 오답 = 빨강
+        return .dimmed                                  // 나머지 흐리게
     }
 
     // 전체 점수(%): 각 문항 점수 평균
@@ -143,7 +155,7 @@ struct QuizSessionView: View {
     }
 }
 
-// 기존 함수 재사용
+// 부분 점수 계산 로직 (기존과 동일)
 private func computeScorePercent(selected: Set<Int>, answers: Set<Int>, optionCount: Int) -> Int {
     let hit = selected.intersection(answers).count
     let wrong = selected.subtracting(answers).count
@@ -156,5 +168,5 @@ private func computeScorePercent(selected: Set<Int>, answers: Set<Int>, optionCo
 }
 
 #Preview {
-    NavigationStack { QuizSessionView() }
+    NavigationStack { QuizSessionView() }   // 샘플 데이터로 미리보기
 }

--- a/EgenBoys/EgenBoys/Source/Feature/QuizPlay/QuizSessionView.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizPlay/QuizSessionView.swift
@@ -10,15 +10,15 @@ import SwiftUI
 // 세션에서 쓰는 질문 모델은 QuizPlayModels.swift에 있음:
 // struct QuizQuestion { let text: String; let options: [String]; let answerIndices: Set<Int> }
 
+
 struct QuizSessionView: View {
-    // ✅ N문제 받아서 풀이 (없으면 샘플로 대체)
     let questions: [QuizQuestion]
     @State private var index: Int = 0
-    @State private var selections: [Int: Set<Int>] = [:]   // 문항별 선택 저장
+    @State private var selections: [Int: Set<Int>] = [:]
+    @State private var revealed: Bool = false               // ✅ 정답 공개 여부
     @State private var showSummary = false
     @State private var finalPercent = 0
 
-    // ✅ 디폴트 init: 인자로 안 주면 샘플 사용
     init(questions: [QuizQuestion]? = nil) {
         self.questions = questions ?? QuizQuestion.sample
     }
@@ -35,8 +35,7 @@ struct QuizSessionView: View {
                     .tint(.blue)
                     .padding(.horizontal)
                 Text("\(index + 1) / \(total)")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
+                    .font(.footnote).foregroundStyle(.secondary)
             }
             .padding(.top, 6)
 
@@ -54,9 +53,12 @@ struct QuizSessionView: View {
                                 CheckboxRow(
                                     index: i + 1,
                                     text: q.options[i],
-                                    isSelected: selected.contains(i)
+                                    isSelected: selected.contains(i),
+                                    feedback: feedbackState(for: i, selected: selected, answers: q.answerIndices)
                                 )
+                                .contentShape(Rectangle())
                                 .onTapGesture {
+                                    guard !revealed else { return } // 공개 후에는 잠금
                                     var s = selections[index] ?? []
                                     if s.contains(i) { s.remove(i) } else { s.insert(i) }
                                     selections[index] = s
@@ -69,23 +71,33 @@ struct QuizSessionView: View {
                 .padding(.bottom, 10)
             }
 
+            // 하단 버튼: 공개 전엔 "정답 확인", 공개 후엔 "다음/제출"
             Button {
-                if index < total - 1 {
-                    index += 1
+                if !revealed {
+                    // 1) 정답 색상 공개
+                    revealed = true
                 } else {
-                    finalPercent = overallPercent()
-                    showSummary = true
+                    // 2) 다음 문제 또는 제출
+                    if index < total - 1 {
+                        index += 1
+                        revealed = false
+                    } else {
+                        finalPercent = overallPercent()
+                        showSummary = true
+                    }
                 }
             } label: {
-                Text(index == total - 1 ? "제출하기" : "다음으로")
+                Text(!revealed
+                     ? "정답 확인"
+                     : (index == total - 1 ? "제출하기" : "다음으로"))
                     .fontWeight(.semibold)
                     .frame(maxWidth: .infinity)
                     .padding()
-                    .background(selected.isEmpty ? Color.gray.opacity(0.3) : Color.blue)
-                    .foregroundColor(selected.isEmpty ? .gray : .white)
+                    .background((selected.isEmpty && !revealed) ? Color.gray.opacity(0.3) : Color.blue)
+                    .foregroundColor((selected.isEmpty && !revealed) ? .gray : .white)
                     .clipShape(RoundedRectangle(cornerRadius: 14))
             }
-            .disabled(selected.isEmpty)
+            .disabled(selected.isEmpty && !revealed)   // 선택 전에는 공개 버튼 비활성화
             .padding(.horizontal, 16)
             .padding(.bottom, 12)
         }
@@ -95,6 +107,7 @@ struct QuizSessionView: View {
             QuizSummaryScoreView(percent: finalPercent) {
                 index = 0
                 selections.removeAll()
+                revealed = false
                 showSummary = false
                 finalPercent = 0
             }
@@ -102,7 +115,20 @@ struct QuizSessionView: View {
         }
     }
 
-    // 각 문항 점수(%) 평균
+    // ✅ 각 옵션의 피드백 상태 계산
+    private func feedbackState(for i: Int, selected: Set<Int>, answers: Set<Int>) -> ChoiceFeedback? {
+        guard revealed else { return nil } // 공개 전엔 색상 피드백 없음
+
+        if answers.contains(i) {                 // 정답은 초록(선택 여부 무관)
+            return .correct
+        } else if selected.contains(i) {         // 선택한 오답은 빨강
+            return .wrong
+        } else {                                 // 나머지는 흐리게
+            return .dimmed
+        }
+    }
+
+    // 전체 점수(%): 각 문항 점수 평균
     private func overallPercent() -> Int {
         guard !questions.isEmpty else { return 0 }
         let percents = questions.enumerated().map { (idx, q) in
@@ -117,7 +143,7 @@ struct QuizSessionView: View {
     }
 }
 
-// 그대로 사용
+// 기존 함수 재사용
 private func computeScorePercent(selected: Set<Int>, answers: Set<Int>, optionCount: Int) -> Int {
     let hit = selected.intersection(answers).count
     let wrong = selected.subtracting(answers).count
@@ -130,6 +156,5 @@ private func computeScorePercent(selected: Set<Int>, answers: Set<Int>, optionCo
 }
 
 #Preview {
-    // 샘플 주입 없이도 동작(디폴트 init)
     NavigationStack { QuizSessionView() }
 }

--- a/EgenBoys/EgenBoys/Source/Feature/QuizPlay/QuizSessionView.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizPlay/QuizSessionView.swift
@@ -12,18 +12,17 @@ struct QuizSessionView: View {
     @State private var currentIndex: Int = 0
     private let totalCount: Int = 1
 
-    @State private var questionText: String =
-        "질문"
-    @State private var options: [String] = [
-        "@1", "@2", "@3", "@4"
-    ]
-    
-    private let answerIndex: Int = 1
+    @State private var questionText: String = "질문"
+    @State private var options: [String] = ["@1", "@2", "@3", "@4"]
 
-    @State private var selectedID: Int? = nil
+    // ✅ 정답(복수 가능) 내가 정하는것
+    private let answerIndices: Set<Int> = [1, 3]
+
+    // ✅ 복수선택 상태
+    @State private var selectedIDs: Set<Int> = []
 
     @State private var showSummary = false
-    @State private var dummyCorrect = 0  // 제출 시 계산해서 채움
+    @State private var scorePercent = 0  // 제출 시 계산해서 채움 (0~100)
 
     var body: some View {
         VStack(spacing: 16) {
@@ -49,10 +48,18 @@ struct QuizSessionView: View {
                     SectionCard("보기") {
                         VStack(spacing: 10) {
                             ForEach(options.indices, id: \.self) { i in
-                                CheckboxRow(index: i+1,
-                                            text: options[i],
-                                            isSelected: selectedID == i)
-                                .onTapGesture { selectedID = i }
+                                CheckboxRow(
+                                    index: i+1,
+                                    text: options[i],
+                                    isSelected: selectedIDs.contains(i)
+                                )
+                                .onTapGesture {
+                                    if selectedIDs.contains(i) {
+                                        selectedIDs.remove(i)
+                                    } else {
+                                        selectedIDs.insert(i)
+                                    }
+                                }
                             }
                         }
                     }
@@ -63,35 +70,61 @@ struct QuizSessionView: View {
 
             // 하단 버튼
             Button {
-                // ✅ 제출 시 정답 체크
-                dummyCorrect = (selectedID == answerIndex) ? 1 : 0
+                // ✅ 부분 점수 계산 → 0~100 퍼센트
+                scorePercent = computeScorePercent(
+                    selected: selectedIDs,
+                    answers: answerIndices,
+                    optionCount: options.count
+                )
                 showSummary = true
             } label: {
                 Text("제출하기")
                     .fontWeight(.semibold)
                     .frame(maxWidth: .infinity)
                     .padding()
-                    .background((selectedID == nil) ? Color.gray.opacity(0.3) : Color.blue)
-                    .foregroundColor((selectedID == nil) ? .gray : .white)
+                    .background(selectedIDs.isEmpty ? Color.gray.opacity(0.3) : Color.blue)
+                    .foregroundColor(selectedIDs.isEmpty ? .gray : .white)
                     .clipShape(RoundedRectangle(cornerRadius: 14))
             }
-            .disabled(selectedID == nil)
+            .disabled(selectedIDs.isEmpty)
             .padding(.horizontal, 16)
             .padding(.bottom, 12)
         }
         .navigationTitle("문제 풀이")
         .navigationBarTitleDisplayMode(.inline)
         .sheet(isPresented: $showSummary) {
-            QuizSummaryView(total: totalCount, correct: dummyCorrect) {
+            // ✅ 퍼센트 기반 요약 뷰
+            QuizSummaryScoreView(percent: scorePercent) {
                 // 닫기 후 리셋
                 currentIndex = 0
-                selectedID = nil
+                selectedIDs.removeAll()
                 showSummary = false
-                dummyCorrect = 0
+                scorePercent = 0
             }
             .presentationDetents([.fraction(0.85)])
         }
     }
+}
+
+// ✅ 부분점수 계산 로직
+/// - hit: 맞게 고른 개수 / 정답 개수  → 기본 가산
+/// - wrong: 오답 선택 개수 / (전체 보기 - 정답 수)  → 패널티 0.5배
+/// - 최종: clamp( (hitRatio) - 0.5*(wrongRatio), 0...1 ) * 100
+private func computeScorePercent(selected: Set<Int>, answers: Set<Int>, optionCount: Int) -> Int {
+    let hit = selected.intersection(answers).count
+    let wrong = selected.subtracting(answers).count
+
+    let answerCount = max(1, answers.count)
+    let nonAnswerCount = max(1, optionCount - answers.count) // 0 분모 방지
+
+    let hitRatio = Double(hit) / Double(answerCount)
+    let wrongRatio = Double(wrong) / Double(nonAnswerCount)
+
+    // 패널티 가중치는 0.5 (원하면 0.3~1.0 사이로 조절)
+    let raw = hitRatio - 0.5 * wrongRatio
+    let clamped = max(0, min(1, raw))
+
+    return Int(round(clamped * 100))
 }
 
 #Preview {

--- a/EgenBoys/EgenBoys/Source/Feature/QuizPlay/QuizSummaryView.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizPlay/QuizSummaryView.swift
@@ -100,7 +100,7 @@ struct QuizSummaryScoreView: View {
                 Button {
                     onClose()
                 } label: {
-                    Text("닫기")
+                    Text("새로운 문제 시도하기")
                         .frame(maxWidth: .infinity)
                         .padding()
                         .background(Color.blue)

--- a/EgenBoys/EgenBoys/Source/Feature/QuizPlay/QuizSummaryView.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizPlay/QuizSummaryView.swift
@@ -1,0 +1,71 @@
+//
+//  QuizSummaryView.swift
+//  EgenBoys
+//
+//  Created by 정수안 on 8/11/25.
+//
+
+import SwiftUI
+
+struct QuizSummaryView: View {
+    let total: Int
+    let correct: Int
+    var onClose: () -> Void
+    
+    var accuracy: String {
+        guard total > 0 else { return "0%" }
+        return String(format: "%.0f%%", (Double(correct) / Double(total)) * 100)
+    }
+    
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 20) {
+                Text("퀴즈 요약")
+                    .font(.title3.bold())
+                
+                VStack(spacing: 12) {
+                    HStack {
+                        Text("총 문제")
+                        Spacer()
+                        Text("\(total)")
+                    }
+                    HStack {
+                        Text("맞힌 개수")
+                        Spacer()
+                        Text("\(correct)")
+                            .foregroundStyle(.blue)
+                            .fontWeight(.semibold)
+                    }
+                    HStack {
+                        Text("정답률")
+                        Spacer()
+                        Text(accuracy)
+                    }
+                }
+                .padding(16)
+                .background(.ultraThinMaterial)
+                .clipShape(RoundedRectangle(cornerRadius: 16))
+                .padding(.horizontal)
+                
+                Button {
+                    onClose()
+                } label: {
+                    Text("닫기")
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.blue)
+                        .foregroundColor(.white)
+                        .clipShape(RoundedRectangle(cornerRadius: 14))
+                }
+                .padding(.horizontal)
+                
+                Spacer()
+            }
+            .padding(.top, 24)
+        }
+    }
+}
+
+#Preview {
+    QuizSummaryView(total: 10, correct: 7, onClose: {})
+}

--- a/EgenBoys/EgenBoys/Source/Feature/QuizPlay/QuizSummaryView.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizPlay/QuizSummaryView.swift
@@ -69,3 +69,49 @@ struct QuizSummaryView: View {
 #Preview {
     QuizSummaryView(total: 10, correct: 7, onClose: {})
 }
+import SwiftUI
+
+struct QuizSummaryScoreView: View {
+    let percent: Int            // 0 ~ 100
+    var onClose: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 20) {
+                Text("퀴즈 요약")
+                    .font(.title3.bold())
+
+                VStack(spacing: 12) {
+                    HStack {
+                        Text("정답률")
+                        Spacer()
+                        Text("\(percent)%")
+                            .fontWeight(.semibold)
+                            .foregroundStyle(.blue)
+                    }
+                    // 필요하면 추가 지표도 표시 가능
+                    // HStack { Text("선택 수"); Spacer(); Text("\(selectedCount)개") }
+                }
+                .padding(16)
+                .background(.ultraThinMaterial)
+                .clipShape(RoundedRectangle(cornerRadius: 16))
+                .padding(.horizontal)
+
+                Button {
+                    onClose()
+                } label: {
+                    Text("닫기")
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.blue)
+                        .foregroundColor(.white)
+                        .clipShape(RoundedRectangle(cornerRadius: 14))
+                }
+                .padding(.horizontal)
+
+                Spacer()
+            }
+            .padding(.top, 24)
+        }
+    }
+}

--- a/EgenBoys/EgenBoys/Source/Feature/QuizPlay/QuizUIComponents.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizPlay/QuizUIComponents.swift
@@ -1,0 +1,60 @@
+//
+//  QuizUIComponents.swift
+//  EgenBoys
+//
+//  Created by 정수안 on 8/11/25.
+//
+
+import SwiftUI
+
+/// 등록 화면 톤과 맞춰 놓기
+struct SectionCard<Content: View>: View {
+    let title: String
+    @ViewBuilder var content: Content
+    
+    init(_ title: String, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.content = content()
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 4)
+            VStack(spacing: 0) {
+                content
+                    .padding(14)
+            }
+            .background(.ultraThinMaterial)
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+        }
+    }
+}
+
+/// 등록 화면 우측 체크박스 톤을 흉내 낸 옵션 셀
+struct CheckboxRow: View {
+    let index: Int
+    let text: String
+    let isSelected: Bool
+    
+    var body: some View {
+        HStack {
+            Text("\(index). \(text)")
+                .frame(maxWidth: .infinity, alignment: .leading)
+            ZStack {
+                RoundedRectangle(cornerRadius: 6)
+                    .strokeBorder(isSelected ? Color.blue : Color.secondary.opacity(0.35), lineWidth: 2)
+                    .frame(width: 26, height: 26)
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 14, weight: .bold))
+                }
+            }
+        }
+        .padding(12)
+        .background(.background)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}

--- a/EgenBoys/EgenBoys/Source/Feature/QuizPlay/QuizUIComponents.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizPlay/QuizUIComponents.swift
@@ -7,47 +7,34 @@
 
 import SwiftUI
 
-// 등록 화면 톤과 맞춘 카드 섹션 (기존과 동일)
+// 그대로 쓰던 섹션 카드
 struct SectionCard<Content: View>: View {
     let title: String
     @ViewBuilder var content: Content
-    
     init(_ title: String, @ViewBuilder content: () -> Content) {
-        self.title = title
-        self.content = content()
+        self.title = title; self.content = content()
     }
-    
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(title)
-                .font(.footnote)
-                .foregroundStyle(.secondary)
-                .padding(.horizontal, 4)
-            VStack(spacing: 0) {
-                content
-                    .padding(14)
-            }
-            .background(.ultraThinMaterial)
-            .clipShape(RoundedRectangle(cornerRadius: 16))
+            Text(title).font(.footnote).foregroundStyle(.secondary).padding(.horizontal, 4)
+            VStack(spacing: 0) { content.padding(14) }
+                .background(.ultraThinMaterial)
+                .clipShape(RoundedRectangle(cornerRadius: 16))
         }
     }
 }
 
-// 보기 피드백 상태
-enum ChoiceFeedback {
-    case correct   // 정답 = 초록
-    case wrong     // 선택한 오답 = 빨강
-    case dimmed    // 정답 공개 후 나머지 = 흐리게
-}
+// ✅ 새로 추가되는 피드백 상태
+enum ChoiceFeedback { case correct, wrong, dimmed }
 
-// 체크박스 옵션 셀 (피드백 색상 지원)
+// ✅ 체크박스(피드백 지원 버전) — 이걸로 교체!
 struct CheckboxRow: View {
     let index: Int
     let text: String
     let isSelected: Bool
-    var feedback: ChoiceFeedback? = nil   // ← 새 파라미터(기본값 nil: 기존 화면 영향 없음)
-    
-    private var strokeColor: Color {
+    var feedback: ChoiceFeedback? = nil   // ← 추가된 파라미터(기본값 있어서 기존 화면 영향 X)
+
+    private var stroke: Color {
         switch feedback {
         case .correct: return .green
         case .wrong:   return .red
@@ -55,8 +42,7 @@ struct CheckboxRow: View {
         case .none:    return isSelected ? .blue : Color.secondary.opacity(0.35)
         }
     }
-    
-    private var bgColor: Color {
+    private var bg: Color {
         switch feedback {
         case .correct: return Color.green.opacity(0.12)
         case .wrong:   return Color.red.opacity(0.12)
@@ -64,32 +50,20 @@ struct CheckboxRow: View {
         case .none:    return Color(.systemBackground)
         }
     }
-    
-    private var textColor: Color {
-        switch feedback {
-        case .dimmed: return .secondary
-        default:      return .primary
-        }
-    }
-    
+    private var txt: Color { feedback == .dimmed ? .secondary : .primary }
+
     var body: some View {
         HStack {
-            Text("\(index). \(text)")
-                .foregroundStyle(textColor)
-                .frame(maxWidth: .infinity, alignment: .leading)
+            Text("\(index). \(text)").foregroundStyle(txt).frame(maxWidth: .infinity, alignment: .leading)
             ZStack {
-                RoundedRectangle(cornerRadius: 6)
-                    .strokeBorder(strokeColor, lineWidth: 2)
-                    .frame(width: 26, height: 26)
+                RoundedRectangle(cornerRadius: 6).strokeBorder(stroke, lineWidth: 2).frame(width: 26, height: 26)
                 if isSelected {
-                    Image(systemName: "checkmark")
-                        .font(.system(size: 14, weight: .bold))
-                        .foregroundStyle(strokeColor)
+                    Image(systemName: "checkmark").font(.system(size: 14, weight: .bold)).foregroundStyle(stroke)
                 }
             }
         }
         .padding(12)
-        .background(bgColor)
+        .background(bg)
         .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 }

--- a/EgenBoys/EgenBoys/Source/Feature/QuizPlay/QuizUIComponents.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizPlay/QuizUIComponents.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-/// 등록 화면 톤과 맞춰 놓기
+// 등록 화면 톤과 맞춘 카드 섹션 (기존과 동일)
 struct SectionCard<Content: View>: View {
     let title: String
     @ViewBuilder var content: Content
@@ -33,28 +33,63 @@ struct SectionCard<Content: View>: View {
     }
 }
 
-/// 등록 화면 우측 체크박스 톤을 흉내 낸 옵션 셀
+// 보기 피드백 상태
+enum ChoiceFeedback {
+    case correct   // 정답 = 초록
+    case wrong     // 선택한 오답 = 빨강
+    case dimmed    // 정답 공개 후 나머지 = 흐리게
+}
+
+// 체크박스 옵션 셀 (피드백 색상 지원)
 struct CheckboxRow: View {
     let index: Int
     let text: String
     let isSelected: Bool
+    var feedback: ChoiceFeedback? = nil   // ← 새 파라미터(기본값 nil: 기존 화면 영향 없음)
+    
+    private var strokeColor: Color {
+        switch feedback {
+        case .correct: return .green
+        case .wrong:   return .red
+        case .dimmed:  return Color.secondary.opacity(0.25)
+        case .none:    return isSelected ? .blue : Color.secondary.opacity(0.35)
+        }
+    }
+    
+    private var bgColor: Color {
+        switch feedback {
+        case .correct: return Color.green.opacity(0.12)
+        case .wrong:   return Color.red.opacity(0.12)
+        case .dimmed:  return Color.secondary.opacity(0.06)
+        case .none:    return Color(.systemBackground)
+        }
+    }
+    
+    private var textColor: Color {
+        switch feedback {
+        case .dimmed: return .secondary
+        default:      return .primary
+        }
+    }
     
     var body: some View {
         HStack {
             Text("\(index). \(text)")
+                .foregroundStyle(textColor)
                 .frame(maxWidth: .infinity, alignment: .leading)
             ZStack {
                 RoundedRectangle(cornerRadius: 6)
-                    .strokeBorder(isSelected ? Color.blue : Color.secondary.opacity(0.35), lineWidth: 2)
+                    .strokeBorder(strokeColor, lineWidth: 2)
                     .frame(width: 26, height: 26)
                 if isSelected {
                     Image(systemName: "checkmark")
                         .font(.system(size: 14, weight: .bold))
+                        .foregroundStyle(strokeColor)
                 }
             }
         }
         .padding(12)
-        .background(.background)
+        .background(bgColor)
         .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 }

--- a/EgenBoys/EgenBoys/Source/Feature/QuizPlay/StartQuizView.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizPlay/StartQuizView.swift
@@ -1,0 +1,67 @@
+//
+//  StartQuizView.swift
+//  EgenBoys
+//
+//  Created by 정수안 on 8/11/25.
+//
+
+import SwiftUI
+
+struct StartQuizView: View {
+    @State private var difficulty: String = "보통"
+    @State private var category: String = "iOS"
+    
+    private let difficulties = ["쉬움","보통","어려움"]
+    private let categories   = ["iOS","Swift","알고리즘","기타"]
+    
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                SectionCard("난이도 및 카테고리") {
+                    HStack {
+                        Text("난이도")
+                        Spacer()
+                        Picker("", selection: $difficulty) {
+                            ForEach(difficulties, id: \.self) { Text($0) }
+                        }
+                        .pickerStyle(.menu)
+                    }
+                    Divider()
+                    HStack {
+                        Text("카테고리")
+                        Spacer()
+                        Picker("", selection: $category) {
+                            ForEach(categories, id: \.self) { Text($0) }
+                        }
+                        .pickerStyle(.menu)
+                    }
+                }
+                
+                NavigationLink {
+                    // 실제 데이터 연동 전: UI 확인용 더미 세션
+                    QuizSessionView()
+                } label: {
+                    Text("시작하기")
+                        .fontWeight(.semibold)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.blue)
+                        .foregroundColor(.white)
+                        .clipShape(RoundedRectangle(cornerRadius: 14))
+                }
+                .padding(.top, 8)
+                
+                Spacer(minLength: 20)
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 20)
+            .padding(.bottom, 24)
+        }
+        .navigationTitle("퀴즈 풀기")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview {
+    NavigationStack { StartQuizView() }
+}

--- a/EgenBoys/EgenBoys/Source/Feature/QuizPlay/StartQuizView.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizPlay/StartQuizView.swift
@@ -38,8 +38,8 @@ struct StartQuizView: View {
                 }
                 
                 NavigationLink {
-                    // 실제 데이터 연동 전: UI 확인용 더미 세션
-                    QuizSessionView()
+                    //🌸여기 바꿈 실제 데이터 연동 전: UI 확인용 더미 세션
+                  QuizSessionView(questions: QuizQuestion.sample)
                 } label: {
                     Text("시작하기")
                         .fontWeight(.semibold)


### PR DESCRIPTION
## 개요
- QuizPlay **UI 구성**(Start → Session → Summary) 추가
- **복수선택** 및 **부분점수(정답률 %)** 표시
- QuizEditor에 **중복 체크** 기능 추가  
  (문제 텍스트/보기 텍스트 기준 – 팀 규칙에 맞춰 조정 가능)

> Closes #<이슈번호>  <!-- 있으면 번호 넣기 -->

---

## 변경 사항 요약
- [x] `StartQuizView`: 난이도/카테고리 선택 카드 + 시작 버튼
- [x] `QuizSessionView`: 문제/선지 카드, 진행도, **복수 선택(Set)** 토글
- [x] `QuizSummaryView`: 정답률(%) 시트로 요약
- [x] `QuizUIComponents`: `SectionCard`, `CheckboxRow` 공통 컴포넌트
- [x] `QuizEditor`: 문제/보기 **중복 체크** 및 경고 처리

---

## 스크린샷
<img width="218" height="442" alt="스크린샷 2025-08-12 오후 2 37 36" src="https://github.com/user-attachments/assets/b7092239-4189-40e3-bf18-ba0ddc882344" />
<img width="213" height="446" alt="스크린샷 2025-08-12 오후 2 37 59" src="https://github.com/user-attachments/assets/2dccfef0-bdee-4cdd-b89a-1337e5391d2b" />




---

## 테스트 방법
1. 앱 실행 → **퀴즈 풀기** 탭 진입
2. Start: 난이도/카테고리 선택 후 **시작하기**
3. Session: 보기 **여러 개 선택** 가능, 선택 없으면 **제출 비활성화**
4. 제출: 요약 시트에서 **정답률(%)** 확인
5. QuizEditor:  
   - 기존 문제 텍스트와 **동일**하면 저장 차단  
   - 하나의 문제 내 **보기 텍스트 중복** 시 차단

---

## 코드 포인트
- 선택 상태: `Set<Int>`로 복수선택 (`contains/insert/remove` 토글)
- 채점 함수: `computeScorePercent(selected:answers:optionCount:)(구글링 참고)
- 패널티 가중치 기본 **0.5** (기획에 따라 조정 가능)

## 리뷰 포인트
- 복수선택 토글/버튼 활성 조건, 요약 시트 노출 타이밍
- 부분점수 로직(패널티 0.5) 적정성
- 공통 컴포넌트 네이밍/폴더링
