### PR TITLE
[FEAT] QuizEditorView에 swiftData 연동

### DIFF
--- a/EgenBoys/EgenBoys/Application/EgenBoysApp.swift
+++ b/EgenBoys/EgenBoys/Application/EgenBoysApp.swift
@@ -16,7 +16,7 @@ struct EgenBoysApp: App {
         WindowGroup {
             MainTabView()
                 .environmentObject(settingsViewModel)
-                .preferredColorScheme(settingsViewModel.isDarkMode ? .dark : .light)
+                .preferredColorScheme(settingsViewModel.colorScheme)
         }
         .modelContainer(for: [Quiz.self, Question.self])
     }

--- a/EgenBoys/EgenBoys/Source/Common/ViewModels/SettingsViewModel.swift
+++ b/EgenBoys/EgenBoys/Source/Common/ViewModels/SettingsViewModel.swift
@@ -7,8 +7,25 @@
 
 import SwiftUI
 
+enum ThemeMode: String, CaseIterable {
+    case system = "시스템 설정"
+    case light = "라이트"
+    case dark = "다크"
+}
+
 class SettingsViewModel: ObservableObject {
-    @AppStorage("isDarkMode") var isDarkMode: Bool = false
+    @AppStorage("themeMode") var themeMode: ThemeMode = .system
     @AppStorage("fontSize") var fontSize: Double = 16
     @AppStorage("isFirstLaunch") var isFirstLaunch: Bool = true
+    
+    var colorScheme: ColorScheme? {
+        switch themeMode {
+        case .light:
+            return .light
+        case .dark:
+            return .dark
+        case .system:
+            return nil
+        }
+    }
 }

--- a/EgenBoys/EgenBoys/Source/Feature/QuizEditor/QuizEditorView.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizEditor/QuizEditorView.swift
@@ -86,6 +86,7 @@ struct QuizEditorView: View {
         let isQuestionEmpty = newQuestion.questionText.trimmingCharacters(in: .whitespaces).isEmpty
         let areAnyOptionsEmpty = newQuestion.answerOptions.contains { option in option.text.trimmingCharacters(in: .whitespaces).isEmpty
         }
+        let isNoAnswerChecked = !newQuestion.answerOptions.contains { $0.isCorrect }
         return isQuestionEmpty || areAnyOptionsEmpty
     }
     

--- a/EgenBoys/EgenBoys/Source/Feature/QuizEditor/QuizEditorView.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizEditor/QuizEditorView.swift
@@ -113,6 +113,14 @@ struct QuizEditorView: View {
                 }
                 
                 Section("보기 및 정답 체크") {
+                    HStack {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.blue)
+                        Text("정답으로 사용할 보기를 체크해주세요.")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                        Spacer()
+                    }
                     VStack {
                         ForEach(newQuestion.answerOptions.indices, id: \.self) { index in
                             AnswerOptionRowView(
@@ -192,6 +200,7 @@ struct QuizEditorView: View {
                 }
                 .listRowInsets(EdgeInsets()) // 버튼 바깥 여백 제거
             }
+            .listRowInsets(EdgeInsets(top: .zero, leading: .zero, bottom: .zero, trailing: .zero))
             .navigationTitle("퀴즈 등록 / 편집")
             .navigationBarTitleDisplayMode(.inline)
             .onChange(of: selectedPhotoItems) { newItems in

--- a/EgenBoys/EgenBoys/Source/Feature/QuizEditor/QuizEditorView.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizEditor/QuizEditorView.swift
@@ -2,7 +2,7 @@
 //  QuizEditorView.swift
 //  EgenBoys
 //
-//  Created by 구현모 on 8/12/25.
+//  Created by 구현모 on 8/13/25.
 //
 
 import SwiftUI
@@ -87,7 +87,7 @@ struct QuizEditorView: View {
         let areAnyOptionsEmpty = newQuestion.answerOptions.contains { option in option.text.trimmingCharacters(in: .whitespaces).isEmpty
         }
         let isNoAnswerChecked = !newQuestion.answerOptions.contains { $0.isCorrect }
-        return isQuestionEmpty || areAnyOptionsEmpty
+        return isQuestionEmpty || areAnyOptionsEmpty || isNoAnswerChecked
     }
     
     struct MediaItem: Identifiable {
@@ -223,6 +223,7 @@ struct QuizEditorView: View {
         }
         .alert("저장 완료", isPresented: $isShowingSaveAlert) {
             Button("확인") {
+                resetInputs()
                 dismiss()
             }
         } message: {
@@ -288,6 +289,14 @@ struct QuizEditorView: View {
             }
         }
         return (savedImageURL, savedVideoURL)
+    }
+    private func resetInputs() {
+        newQuestion = CreateQuestion()
+        
+        selectedDifficulty = .medium
+        selectedCategory = .ios
+        selectedPhotoItems = []
+        selectedMediaItems = []
     }
     
     @ViewBuilder

--- a/EgenBoys/EgenBoys/Source/Feature/QuizEditor/QuizEditorView.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizEditor/QuizEditorView.swift
@@ -82,6 +82,13 @@ struct QuizEditorView: View {
     
     @State private var isShowingSaveAlert = false
     
+    private var isSaveButtonDisabled: Bool {
+        let isQuestionEmpty = newQuestion.questionText.trimmingCharacters(in: .whitespaces).isEmpty
+        let areAnyOptionsEmpty = newQuestion.answerOptions.contains { option in option.text.trimmingCharacters(in: .whitespaces).isEmpty
+        }
+        return isQuestionEmpty || areAnyOptionsEmpty
+    }
+    
     struct MediaItem: Identifiable {
         let id = UUID()
         let type: MediaType
@@ -177,9 +184,10 @@ struct QuizEditorView: View {
                     }
                     .frame(minWidth: 0, maxWidth: .infinity)
                     .padding()
-                    .background(Color.blue)
+                    .background(isSaveButtonDisabled ? Color.gray : Color.blue)
                     .foregroundColor(.white)
                     .cornerRadius(8)
+                    .disabled(isSaveButtonDisabled)
                 }
                 .listRowInsets(EdgeInsets()) // 버튼 바깥 여백 제거
             }

--- a/EgenBoys/EgenBoys/Source/Feature/QuizList/QuizDetailView.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizList/QuizDetailView.swift
@@ -6,9 +6,11 @@
 //
 
 import SwiftUI
+import AVKit
 
 struct QuizDetailView: View {
     let item: Quiz
+    @State var playingQuizID: UUID?
     
     var body: some View {
         ScrollView {
@@ -66,15 +68,29 @@ struct QuizDetailView: View {
                     .shadow(color: .black.opacity(0.1), radius: 5, x: 0, y: 2)
                     .padding(.top, 10)
                 
-                if let videoURL = item.videoURL {
-                    Link("Watch Video", destination: videoURL)
+                Button(action: {
+                    playingQuizID = item.id
+                }) {
+                    Text("동영상 보기")
                         .font(.headline)
                         .foregroundColor(.blue)
                         .padding()
                         .frame(maxWidth: .infinity)
                         .background(RoundedRectangle(cornerRadius: 10).stroke(Color.blue, lineWidth: 1))
-                        .padding(.top, 10)
                 }
+                .padding(.horizontal)
+                if playingQuizID == item.id {
+                    if let videoURL = item.videoURL {
+                        VideoPlayer(player: AVPlayer(url: videoURL))
+                            .frame(height: 200)
+                            .cornerRadius(15)
+                            .padding()
+                            .onTapGesture {
+                                playingQuizID = nil
+                            }
+                    }
+                }
+                        
             }
             .padding(.top, 20)
             .padding(.bottom, 40)

--- a/EgenBoys/EgenBoys/Source/Feature/Settings/SettingsView.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/Settings/SettingsView.swift
@@ -18,7 +18,11 @@ struct SettingsView: View {
         NavigationStack {
             Form {
                 Section("테마 설정") {
-                    Toggle("다크 모드", isOn: $settings.isDarkMode)
+                    Picker("테마", selection: $settings.themeMode) {
+                        ForEach(ThemeMode.allCases, id: \.self) { mode in
+                            Text(mode.rawValue)
+                        }
+                    }
                 }
                 Section(header: Text("폰트 크기")) {
                     Slider(value: $temporaryFontSize, in: 12...24, step: 1)
@@ -56,7 +60,7 @@ struct SettingsPreviewWrapper: View {
     var body: some View {
         SettingsView()
             .environmentObject(settingsViewModel)
-            .preferredColorScheme(settingsViewModel.isDarkMode ? .dark : .light)
+            .preferredColorScheme(settingsViewModel.colorScheme)
     }
 }
 #Preview {


### PR DESCRIPTION
# **작업 내용**
- 다크 모드 전환 토글을 Picker로 변경 (기본값은 시스템 설정)
- 퀴즈 저장 시 저장 버튼 비활성화 로직 추가 (문제, 선택지, 정답을 입력하지 않으면 버튼이 활성화되지 않습니다.)
- 퀴즈 저장 시 입력창 초기화, 저장 안내 alert 기능 구현
- QuizDetailView 동영상 보기 버튼 패딩 설정 및 비디오 재생 기능 구현
- QuizEditorView에서 정답 선택 안내 메시지 추가 및 ui 양쪽 여백 개선
# **화면**
| 다크모드 전환 토글 변경 | 저장 버튼 비활성화 |
| :-: | :-: |
| <img width="332" height="697" alt="스크린샷 2025-08-13 16 41 26" src="https://github.com/user-attachments/assets/e7253543-7d44-421b-948f-81118df233f4" /> | <img width="332" height="697" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-13 at 16 43 10" src="https://github.com/user-attachments/assets/90a8522c-84d0-4c7d-9e8d-3706984132e5" /> |

| 정답 체크 안내 메시지 추가 |
| :-: |
| <img width="332" height="697" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-13 at 16 51 10" src="https://github.com/user-attachments/assets/b568b3c4-e7ad-40e3-a16f-2c8d4e5671cb" /> | 

### 저장 시 입력창 초기화, 저장 안내 alert
https://github.com/user-attachments/assets/340c0c14-ee9f-4669-a6dd-6266be974a91

### QuizDetailView 동영상 보기 버튼 패딩 설정 및 비디오 재생 기능
https://github.com/user-attachments/assets/65954f96-003b-4183-b16b-f3b539d52905

# **논의 해봤으면 좋은 점**
- @dlrjswns 건준님이 구현해주신 퀴즈 목록 화면에서 퀴즈를 삭제하는 버튼이나 스와이프해서 퀴즈를 삭제할 수 있게 해주시면 좋을 것 같습니다.
- 향후 수안님이 대시보드 뷰 병합해주시면 설정 진입 버튼 추가하도록 하겠습니다.
