### PR TITLE
[FEAT] QuizSessionView ‘정답으로 사용할 보기를 체크해주세요’ 안내문 추가

### DIFF
--- a/EgenBoys/EgenBoys/Source/Feature/QuizPlay/QuizSessionView.swift
+++ b/EgenBoys/EgenBoys/Source/Feature/QuizPlay/QuizSessionView.swift
@@ -7,8 +7,26 @@
 
 import SwiftUI
 
-// QuizQuestion / ChoiceFeedback / SectionCard / CheckboxRow 는
-// 각각 QuizPlayModels.swift / QuizUIComponents.swift 에 있다고 가정합니다.
+
+///
+private struct InfoNote: View {
+    var text: String
+    var body: some View {
+        HStack(alignment: .center, spacing: 8) {
+            Image(systemName: "checkmark.circle.fill")
+                .imageScale(.medium)
+                .foregroundStyle(.blue)
+            Text(text)
+                .font(.subheadline)
+                .foregroundStyle(.primary)
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .background(Color(.systemGray6))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .accessibilityElement(children: .combine)
+    }
+}
 
 struct QuizSessionView: View {
     
@@ -53,20 +71,26 @@ struct QuizSessionView: View {
                     }
 
                     SectionCard("보기") {
-                        VStack(spacing: 10) {
-                            ForEach(q.options.indices, id: \.self) { i in
-                                CheckboxRow(
-                                    index: i + 1,
-                                    text: q.options[i],
-                                    isSelected: selected.contains(i),
-                                    feedback: feedbackState(for: i, selected: selected, answers: q.answerIndices)
-                                )
-                                .contentShape(Rectangle())
-                                .onTapGesture {
-                                    guard !revealed else { return } // 공개 후엔 잠금
-                                    var s = selections[index] ?? []
-                                    if s.contains(i) { s.remove(i) } else { s.insert(i) }
-                                    selections[index] = s
+                        VStack(spacing: 12) {
+
+                            // ⬇️ 등록/편집 화면과 동일 톤의 설명 박스 추가
+                            InfoNote(text: "정답으로 사용할 보기를 체크해주세요.")
+
+                            VStack(spacing: 10) {
+                                ForEach(q.options.indices, id: \.self) { i in
+                                    CheckboxRow(
+                                        index: i + 1,
+                                        text: q.options[i],
+                                        isSelected: selected.contains(i),
+                                        feedback: feedbackState(for: i, selected: selected, answers: q.answerIndices)
+                                    )
+                                    .contentShape(Rectangle())
+                                    .onTapGesture {
+                                        guard !revealed else { return } // 공개 후엔 잠금
+                                        var s = selections[index] ?? []
+                                        if s.contains(i) { s.remove(i) } else { s.insert(i) }
+                                        selections[index] = s
+                                    }
                                 }
                             }
                         }
@@ -170,3 +194,4 @@ private func computeScorePercent(selected: Set<Int>, answers: Set<Int>, optionCo
 #Preview {
     NavigationStack { QuizSessionView() }   // 샘플 데이터로 미리보기
 }
+


### PR DESCRIPTION
## 📌 개요
- 퀴즈 **등록/편집 화면과 톤을 맞춘 안내 문구**를 풀이 화면의 `보기` 섹션 상단에 추가했습니다.  
- 사용자가 정답 선택 방식(복수 선택 가능)을 바로 이해하도록 돕습니다.

---

## 🔨 변경 사항
- **QuizSessionView.swift**
  - `InfoNote` 컴포넌트(로컬 뷰) 추가
  - `SectionCard("보기")` 상단에 `InfoNote(text: "정답으로 사용할 보기를 체크해주세요.")` 배치
  - 기존 로직/상호작용에는 영향 없음 (선택/정답 확인/다음/제출 흐름 동일)

---

## 🖼️ 스크린샷 / 동작
<img width="205" height="425" alt="스크린샷 2025-08-17 오후 3 57 09" src="https://github.com/user-attachments/assets/e7ca3330-afa2-43e2-ad08-1e7c8102eafb" />

- **Before**: 보기 리스트만 표시  
- **After**: 보기 상단에 회색 배경의 안내 박스 노출  
  *(Xcode Preview / iPhone 16 Pro 기준)*

---

## ✅ 테스트 방법
1. 앱 실행 후 임의의 퀴즈에서 `QuizSessionView` 진입  
2. `보기` 섹션 상단에 안내 박스가 표시되는지 확인  
3. 보기 선택 → **정답 확인** → 색상 피드백, 다음/제출 흐름 정상 동작 확인  
4. 안내 박스가 정답 공개 여부와 무관하게 항상 상단에 표시되는지 확인  

---

## 📂 영향 범위
- UI 가이드 추가만 포함  
- 계산/네비게이션/점수 집계 로직에는 변경 없음  
- 다른 화면(등록/편집/요약)에는 영향 없음  

---

## ☑️ 체크리스트
- [x] 빌드 성공  
- [x] 런타임 크래시 없음  
- [x] 다크모드/라이트모드 가독성 문제 없음  
- [x] 접근성: 안내문이 VoiceOver에서 한 문장으로 읽힘  

---

## 🔗 관련 이슈
- 없음 (또는 `Closes #이슈번호`)  
